### PR TITLE
feat: add site tab and domain switching

### DIFF
--- a/src/app/keywords/page.js
+++ b/src/app/keywords/page.js
@@ -18,6 +18,7 @@ export default function KeywordManager() {
   const [newSobang, setNewSobang] = useState("");
   const [newSobangColor, setNewSobangColor] = useState("#000000");
   const [drag, setDrag] = useState(null);
+  const [site, setSite] = useState("megagong");
 
   useEffect(() => {
     if (allowed === false) router.replace("/");
@@ -106,6 +107,26 @@ export default function KeywordManager() {
   return (
     <div className={styles.container}>
       <h1>키워드 관리자</h1>
+      <div className={styles.tabBar}>
+        <button
+          type="button"
+          className={`${styles.tabButton} ${
+            site === "megagong" ? styles.activeTab : ""
+          }`}
+          onClick={() => setSite("megagong")}
+        >
+          넥스트공무원
+        </button>
+        <button
+          type="button"
+          className={`${styles.tabButton} ${
+            site === "gong" ? styles.activeTab : ""
+          }`}
+          onClick={() => setSite("gong")}
+        >
+          공단기
+        </button>
+      </div>
       <div className={styles.groups}>
         <div className={styles.group}>
           <h2 className={styles.groupTitle}>공무원</h2>

--- a/src/app/keywords/page.module.scss
+++ b/src/app/keywords/page.module.scss
@@ -10,6 +10,24 @@
   }
 }
 
+.tabBar {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.tabButton {
+  padding: 6px 12px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  cursor: pointer;
+}
+
+.activeTab {
+  font-weight: 700;
+  border-bottom: 2px solid currentColor;
+}
+
 .groups {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -73,11 +73,14 @@ function rankText(value) {
 }
 
 // ====== API ======
-async function fetchRank(keyword) {
+async function fetchRank(keyword, site) {
   try {
-    const res = await fetch(`/api/rank/${encodeURIComponent(keyword)}`, {
-      method: "GET"
-    });
+    const res = await fetch(
+      `/api/rank/${encodeURIComponent(keyword)}?site=${site}`,
+      {
+        method: "GET"
+      }
+    );
     if (!res.ok) throw new Error("검색 실패");
     const data = await res.json();
     return {
@@ -94,6 +97,7 @@ async function fetchRank(keyword) {
 /** 키워드 배열을 1초 간격으로 순차 fetch + 실패 재시도 */
 async function fetchSequentially(
   keywords,
+  site,
   retryCount = 5,
   onUpdate = () => {}
 ) {
@@ -108,7 +112,7 @@ async function fetchSequentially(
   }
 
   for (const kw of keywords) {
-    const r = await fetchRank(kw);
+    const r = await fetchRank(kw, site);
     results[r.keyword] = r.rank;
     sources[r.keyword] = r.source;
     counts[r.keyword] = r.top10Count;
@@ -123,7 +127,7 @@ async function fetchSequentially(
     failed = [];
     for (const kw of retryTargets) {
       onUpdate(kw, "loading", "", 0);
-      const r = await fetchRank(kw);
+      const r = await fetchRank(kw, site);
       results[r.keyword] = r.rank;
       sources[r.keyword] = r.source;
       counts[r.keyword] = r.top10Count;
@@ -238,6 +242,7 @@ export default function Home() {
   const [msg, setMsg] = useState(null);
   const [theme, setTheme] = useState("light");
   const [isNotProdDomain, setIsNotProdDomain] = useState(false);
+  const [site, setSite] = useState("megagong");
   useEffect(() => {
     if (typeof window !== "undefined") {
       setIsNotProdDomain(
@@ -512,6 +517,7 @@ export default function Home() {
     const nextCount = { ...gongCount };
     const result = await fetchSequentially(
       gongKeywords,
+      site,
       5,
       (kw, val, src, cnt) => {
         nextRank[kw] = val;
@@ -542,6 +548,7 @@ export default function Home() {
     const nextCount = { ...sobangCount };
     const result = await fetchSequentially(
       sobangKeywords,
+      site,
       5,
       (kw, val, src, cnt) => {
         nextRank[kw] = val;
@@ -610,6 +617,26 @@ export default function Home() {
       <h1 className={styles.title}>
         NS <span>(Next SEO Master)</span>
       </h1>
+      <div className={styles.tabBar}>
+        <button
+          className={`${styles.tabButton} ${
+            site === "megagong" ? styles.activeTab : ""
+          }`}
+          onClick={() => setSite("megagong")}
+          type="button"
+        >
+          넥스트공무원
+        </button>
+        <button
+          className={`${styles.tabButton} ${
+            site === "gong" ? styles.activeTab : ""
+          }`}
+          onClick={() => setSite("gong")}
+          type="button"
+        >
+          공단기
+        </button>
+      </div>
       {hasPermission && isNotProdDomain && (
         <>
           <h2 className={styles.subTitle}>구글 검색 순위 비교(SEO)</h2>

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -29,6 +29,24 @@
     font-size: 14px;
   }
 
+  .tabBar {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+
+  .tabButton {
+    padding: 6px 12px;
+    border: 1px solid var(--line);
+    background: var(--panel);
+    cursor: pointer;
+  }
+
+  .activeTab {
+    font-weight: 700;
+    border-bottom: 2px solid currentColor;
+  }
+
   /* ===== Crawling Area ===== */
   .keywordGrid {
     display: grid;

--- a/src/pages/api/rank/[keyword].js
+++ b/src/pages/api/rank/[keyword].js
@@ -9,7 +9,7 @@ export default async function handler(req, res) {
     return res.status(405).json({ error: "GET 요청만 허용됩니다." });
   }
 
-  const { keyword } = req.query;
+  const { keyword, site } = req.query;
 
   if (!keyword) {
     return res.status(400).json({ error: "키워드를 입력해주세요." });
@@ -33,13 +33,12 @@ export default async function handler(req, res) {
     );
 
     let currentPage = 1;
+    const targetDomain =
+      site === "gong" ? "gong.conects.com" : "megagong.net";
     let searchResults = [];
-    // let foundMegagongRank = null;
-    // let foundMegagongUrl = null;
-    // let megagongTop10Count = 0;
-    let foundGongRank = null;
-    let foundGongUrl = null;
-    let gongTop10Count = 0;
+    let foundRank = null;
+    let foundUrl = null;
+    let top10Count = 0;
 
     while (currentPage <= 5) {
       const searchURL = `https://www.google.com/search?q=${encodeURIComponent(
@@ -69,27 +68,16 @@ export default async function handler(req, res) {
 
       searchResults = searchResults.concat(pageResults);
 
-      // const megagongResult = searchResults.find((result) =>
-      //   result.url.includes("megagong.net")
-      // );
-      // megagongTop10Count = searchResults.filter(
-      //   (r) => r.url.includes("megagong.net") && r.rank <= 10
-      // ).length;
-      const gongResult = searchResults.find((result) =>
-        result.url.includes("gong.conects.com")
+      const domainResult = searchResults.find((result) =>
+        result.url.includes(targetDomain)
       );
-      gongTop10Count = searchResults.filter(
-        (r) => r.url.includes("gong.conects.com") && r.rank <= 10
+      top10Count = searchResults.filter(
+        (r) => r.url.includes(targetDomain) && r.rank <= 10
       ).length;
 
-      // if (megagongResult) {
-      //   foundMegagongRank = megagongResult.rank;
-      //   foundMegagongUrl = megagongResult.url;
-      //   break;
-      // }
-      if (gongResult) {
-        foundGongRank = gongResult.rank;
-        foundGongUrl = gongResult.url;
+      if (domainResult) {
+        foundRank = domainResult.rank;
+        foundUrl = domainResult.url;
         break;
       }
 
@@ -97,18 +85,11 @@ export default async function handler(req, res) {
     }
 
     await browser.close();
-    // res.status(200).json({
-    //   keyword,
-    //   activeRank: foundMegagongRank ? foundMegagongRank : "N/A",
-    //   sourceUrl: foundMegagongUrl,
-    //   top10Count: megagongTop10Count,
-    //   results: searchResults
-    // });
     res.status(200).json({
       keyword,
-      activeRank: foundGongRank ? foundGongRank : "N/A",
-      sourceUrl: foundGongUrl,
-      top10Count: gongTop10Count,
+      activeRank: foundRank ? foundRank : "N/A",
+      sourceUrl: foundUrl,
+      top10Count,
       results: searchResults
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- add tab component to choose between 넥스트공무원 and 공단기
- send selected site to rank API and switch target domain
- style new tabs on main and keyword pages

## Testing
- `npm test` *(fails: Missing script "test"))*
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68b69bc276908321826f370678e3b4ad