### PR TITLE
feat: separate keywords by site

### DIFF
--- a/src/app/keywords/page.js
+++ b/src/app/keywords/page.js
@@ -11,12 +11,10 @@ import styles from "./page.module.scss";
 export default function KeywordManager() {
   const router = useRouter();
   const allowed = useKeywordPermission();
-  const [gong, setGong] = useState([]);
-  const [sobang, setSobang] = useState([]);
-  const [newGong, setNewGong] = useState("");
-  const [newGongColor, setNewGongColor] = useState("#000000");
-  const [newSobang, setNewSobang] = useState("");
-  const [newSobangColor, setNewSobangColor] = useState("#000000");
+  const [site, setSite] = useState("megagong");
+  const [keywords, setKeywords] = useState([]);
+  const [newKeyword, setNewKeyword] = useState("");
+  const [newColor, setNewColor] = useState("#000000");
   const [drag, setDrag] = useState(null);
 
   useEffect(() => {
@@ -25,119 +23,118 @@ export default function KeywordManager() {
 
   useEffect(() => {
     if (allowed !== true || !db) return;
-    const unsubG = onSnapshot(doc(db, "keywords", "gong"), async (snap) => {
+    const unsub = onSnapshot(doc(db, "keywords", site), async (snap) => {
       const list = snap.data()?.list || [];
       const mapped = list.map((item) =>
         typeof item === "string" ? { keyword: item, color: "#000000" } : item
       );
-      setGong(mapped);
+      setKeywords(mapped);
       if (list.some((item) => typeof item === "string")) {
-        await setDoc(doc(db, "keywords", "gong"), { list: mapped });
+        await setDoc(doc(db, "keywords", site), { list: mapped });
       }
     });
-    const unsubS = onSnapshot(doc(db, "keywords", "sobang"), async (snap) => {
-      const list = snap.data()?.list || [];
-      const mapped = list.map((item) =>
-        typeof item === "string" ? { keyword: item, color: "#000000" } : item
-      );
-      setSobang(mapped);
-      if (list.some((item) => typeof item === "string")) {
-        await setDoc(doc(db, "keywords", "sobang"), { list: mapped });
-      }
-    });
-    return () => {
-      unsubG();
-      unsubS();
-    };
-  }, [allowed]);
+    return () => unsub();
+  }, [allowed, site]);
 
   if (allowed !== true) return null;
 
-  const update = async (group, arr) => {
+  const update = async (arr) => {
     if (!db) return;
-    await setDoc(doc(db, "keywords", group), { list: arr });
+    await setDoc(doc(db, "keywords", site), { list: arr });
   };
 
-  const add = async (group) => {
-    const value = group === "gong" ? newGong.trim() : newSobang.trim();
-    const color = group === "gong" ? newGongColor : newSobangColor;
+  const add = async () => {
+    const value = newKeyword.trim();
     if (!value) return;
-    const item = { keyword: value, color };
-    const arr = group === "gong" ? [...gong, item] : [...sobang, item];
-    await update(group, arr);
-    if (group === "gong") {
-      setNewGong("");
-      setNewGongColor("#000000");
-    } else {
-      setNewSobang("");
-      setNewSobangColor("#000000");
-    }
+    const item = { keyword: value, color: newColor };
+    const arr = [...keywords, item];
+    await update(arr);
+    setNewKeyword("");
+    setNewColor("#000000");
   };
 
-  const remove = async (group, index) => {
-    const arr = group === "gong" ? [...gong] : [...sobang];
+  const remove = async (index) => {
+    const arr = [...keywords];
     arr.splice(index, 1);
-    await update(group, arr);
+    await update(arr);
   };
 
-  const changeColor = async (group, index, color) => {
-    const arr = group === "gong" ? [...gong] : [...sobang];
+  const changeColor = async (index, color) => {
+    const arr = [...keywords];
     const item = arr[index];
     arr[index] =
       typeof item === "string" ? { keyword: item, color } : { ...item, color };
-    if (group === "gong") setGong(arr);
-    else setSobang(arr);
-    await update(group, arr);
+    setKeywords(arr);
+    await update(arr);
   };
 
-  const onDragStart = (group, index) => {
-    setDrag({ group, index });
+  const onDragStart = (index) => {
+    setDrag(index);
   };
 
-  const onDrop = async (group, index) => {
-    if (!drag || drag.group !== group) return setDrag(null);
-    const arr = group === "gong" ? [...gong] : [...sobang];
-    const [moved] = arr.splice(drag.index, 1);
+  const onDrop = async (index) => {
+    if (drag === null) return setDrag(null);
+    const arr = [...keywords];
+    const [moved] = arr.splice(drag, 1);
     arr.splice(index, 0, moved);
     setDrag(null);
-    await update(group, arr);
+    await update(arr);
   };
+
+  const siteLabel = site === "megagong" ? "넥스트공무원" : "공단기";
 
   return (
     <div className={styles.container}>
       <h1>키워드 관리자</h1>
+      <div className={styles.tabBar}>
+        <button
+          type="button"
+          className={`${styles.tabButton} ${
+            site === "megagong" ? styles.activeTab : ""
+          }`}
+          onClick={() => setSite("megagong")}
+        >
+          넥스트공무원
+        </button>
+        <button
+          type="button"
+          className={`${styles.tabButton} ${
+            site === "gong" ? styles.activeTab : ""
+          }`}
+          onClick={() => setSite("gong")}
+        >
+          공단기
+        </button>
+      </div>
       <div className={styles.groups}>
         <div className={styles.group}>
-          <h2 className={styles.groupTitle}>공무원</h2>
+          <h2 className={styles.groupTitle}>{siteLabel}</h2>
           <ul className={styles.list}>
-            {gong.map((kw, idx) => (
+            {keywords.map((kw, idx) => (
               <li
                 key={kw.keyword}
                 className={styles.item}
                 draggable
-                onDragStart={() => onDragStart("gong", idx)}
+                onDragStart={() => onDragStart(idx)}
                 onDragOver={(e) => e.preventDefault()}
-                onDrop={() => onDrop("gong", idx)}
+                onDrop={() => onDrop(idx)}
               >
                 <div className={styles.keyword}>
                   <input
                     type="color"
                     className={styles.colorInput}
                     value={kw.color || "#000000"}
-                    onChange={(e) => changeColor("gong", idx, e.target.value)}
+                    onChange={(e) => changeColor(idx, e.target.value)}
                   />
                   <input
                     type="text"
                     className={styles.colorTextInput}
                     value={kw.color || "#000000"}
-                    onChange={(e) => changeColor("gong", idx, e.target.value)}
+                    onChange={(e) => changeColor(idx, e.target.value)}
                   />
                   <span>{kw.keyword}</span>
                 </div>
-                <button
-                  className={styles.button}
-                  onClick={() => remove("gong", idx)}
-                >
+                <button className={styles.button} onClick={() => remove(idx)}>
                   삭제
                 </button>
               </li>
@@ -147,84 +144,23 @@ export default function KeywordManager() {
             <input
               type="color"
               className={styles.colorInput}
-              value={newGongColor}
-              onChange={(e) => setNewGongColor(e.target.value)}
+              value={newColor}
+              onChange={(e) => setNewColor(e.target.value)}
             />
             <input
               type="text"
               className={styles.colorTextInput}
-              value={newGongColor}
-              onChange={(e) => setNewGongColor(e.target.value)}
+              value={newColor}
+              onChange={(e) => setNewColor(e.target.value)}
             />
             <input
               type="text"
               className={styles.keywordInput}
-              value={newGong}
-              onChange={(e) => setNewGong(e.target.value)}
+              value={newKeyword}
+              onChange={(e) => setNewKeyword(e.target.value)}
               placeholder="키워드 추가"
             />
-            <button className={styles.button} onClick={() => add("gong")}>
-              추가
-            </button>
-          </div>
-        </div>
-        <div className={styles.group}>
-          <h2 className={styles.groupTitle}>소방</h2>
-          <ul className={styles.list}>
-            {sobang.map((kw, idx) => (
-              <li
-                key={kw.keyword}
-                className={styles.item}
-                draggable
-                onDragStart={() => onDragStart("sobang", idx)}
-                onDragOver={(e) => e.preventDefault()}
-                onDrop={() => onDrop("sobang", idx)}
-              >
-                <div className={styles.keyword}>
-                  <input
-                    type="color"
-                    className={styles.colorInput}
-                    value={kw.color || "#000000"}
-                    onChange={(e) => changeColor("sobang", idx, e.target.value)}
-                  />
-                  <input
-                    type="text"
-                    className={styles.colorTextInput}
-                    value={kw.color || "#000000"}
-                    onChange={(e) => changeColor("sobang", idx, e.target.value)}
-                  />
-                  <span>{kw.keyword}</span>
-                </div>
-                <button
-                  className={styles.button}
-                  onClick={() => remove("sobang", idx)}
-                >
-                  삭제
-                </button>
-              </li>
-            ))}
-          </ul>
-          <div className={styles.controls}>
-            <input
-              type="color"
-              className={styles.colorInput}
-              value={newSobangColor}
-              onChange={(e) => setNewSobangColor(e.target.value)}
-            />
-            <input
-              type="text"
-              className={styles.colorTextInput}
-              value={newSobangColor}
-              onChange={(e) => setNewSobangColor(e.target.value)}
-            />
-            <input
-              type="text"
-              className={styles.keywordInput}
-              value={newSobang}
-              onChange={(e) => setNewSobang(e.target.value)}
-              placeholder="키워드 추가"
-            />
-            <button className={styles.button} onClick={() => add("sobang")}>
+            <button className={styles.button} onClick={add}>
               추가
             </button>
           </div>
@@ -236,3 +172,4 @@ export default function KeywordManager() {
     </div>
   );
 }
+

--- a/src/app/keywords/page.module.scss
+++ b/src/app/keywords/page.module.scss
@@ -10,15 +10,27 @@
   }
 }
 
-.groups {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 32px;
-  margin-top: 20px;
+.tabBar {
+  display: flex;
+  gap: 8px;
+  margin-top: 12px;
+}
 
-  @media (max-width: 768px) {
-    grid-template-columns: 1fr;
-  }
+.tabButton {
+  padding: 6px 12px;
+  border: 1px solid var(--line);
+  background: var(--panel);
+  cursor: pointer;
+}
+
+.activeTab {
+  font-weight: 700;
+  border-bottom: 2px solid currentColor;
+}
+
+
+.groups {
+  margin-top: 20px;
 }
 
 .group {

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -73,11 +73,14 @@ function rankText(value) {
 }
 
 // ====== API ======
-async function fetchRank(keyword) {
+async function fetchRank(keyword, site) {
   try {
-    const res = await fetch(`/api/rank/${encodeURIComponent(keyword)}`, {
-      method: "GET"
-    });
+    const res = await fetch(
+      `/api/rank/${encodeURIComponent(keyword)}?site=${site}`,
+      {
+        method: "GET"
+      }
+    );
     if (!res.ok) throw new Error("검색 실패");
     const data = await res.json();
     return {
@@ -94,6 +97,7 @@ async function fetchRank(keyword) {
 /** 키워드 배열을 1초 간격으로 순차 fetch + 실패 재시도 */
 async function fetchSequentially(
   keywords,
+  site,
   retryCount = 5,
   onUpdate = () => {}
 ) {
@@ -108,7 +112,7 @@ async function fetchSequentially(
   }
 
   for (const kw of keywords) {
-    const r = await fetchRank(kw);
+    const r = await fetchRank(kw, site);
     results[r.keyword] = r.rank;
     sources[r.keyword] = r.source;
     counts[r.keyword] = r.top10Count;
@@ -123,7 +127,7 @@ async function fetchSequentially(
     failed = [];
     for (const kw of retryTargets) {
       onUpdate(kw, "loading", "", 0);
-      const r = await fetchRank(kw);
+      const r = await fetchRank(kw, site);
       results[r.keyword] = r.rank;
       sources[r.keyword] = r.source;
       counts[r.keyword] = r.top10Count;
@@ -238,6 +242,7 @@ export default function Home() {
   const [msg, setMsg] = useState(null);
   const [theme, setTheme] = useState("light");
   const [isNotProdDomain, setIsNotProdDomain] = useState(false);
+  const [site, setSite] = useState("megagong");
   useEffect(() => {
     if (typeof window !== "undefined") {
       setIsNotProdDomain(
@@ -512,6 +517,7 @@ export default function Home() {
     const nextCount = { ...gongCount };
     const result = await fetchSequentially(
       gongKeywords,
+      site,
       5,
       (kw, val, src, cnt) => {
         nextRank[kw] = val;
@@ -542,6 +548,7 @@ export default function Home() {
     const nextCount = { ...sobangCount };
     const result = await fetchSequentially(
       sobangKeywords,
+      site,
       5,
       (kw, val, src, cnt) => {
         nextRank[kw] = val;
@@ -610,6 +617,26 @@ export default function Home() {
       <h1 className={styles.title}>
         NS <span>(Next SEO Master)</span>
       </h1>
+      <div className={styles.tabBar}>
+        <button
+          className={`${styles.tabButton} ${
+            site === "megagong" ? styles.activeTab : ""
+          }`}
+          onClick={() => setSite("megagong")}
+          type="button"
+        >
+          넥스트공무원
+        </button>
+        <button
+          className={`${styles.tabButton} ${
+            site === "gong" ? styles.activeTab : ""
+          }`}
+          onClick={() => setSite("gong")}
+          type="button"
+        >
+          공단기
+        </button>
+      </div>
       {hasPermission && isNotProdDomain && (
         <>
           <h2 className={styles.subTitle}>구글 검색 순위 비교(SEO)</h2>

--- a/src/app/page.module.scss
+++ b/src/app/page.module.scss
@@ -29,6 +29,24 @@
     font-size: 14px;
   }
 
+  .tabBar {
+    display: flex;
+    gap: 8px;
+    margin-bottom: 16px;
+  }
+
+  .tabButton {
+    padding: 6px 12px;
+    border: 1px solid var(--line);
+    background: var(--panel);
+    cursor: pointer;
+  }
+
+  .activeTab {
+    font-weight: 700;
+    border-bottom: 2px solid currentColor;
+  }
+
   /* ===== Crawling Area ===== */
   .keywordGrid {
     display: grid;

--- a/src/pages/api/rank/[keyword].js
+++ b/src/pages/api/rank/[keyword].js
@@ -9,7 +9,7 @@ export default async function handler(req, res) {
     return res.status(405).json({ error: "GET 요청만 허용됩니다." });
   }
 
-  const { keyword } = req.query;
+  const { keyword, site } = req.query;
 
   if (!keyword) {
     return res.status(400).json({ error: "키워드를 입력해주세요." });
@@ -33,13 +33,12 @@ export default async function handler(req, res) {
     );
 
     let currentPage = 1;
+    const targetDomain =
+      site === "gong" ? "gong.conects.com" : "megagong.net";
     let searchResults = [];
-    // let foundMegagongRank = null;
-    // let foundMegagongUrl = null;
-    // let megagongTop10Count = 0;
-    let foundGongRank = null;
-    let foundGongUrl = null;
-    let gongTop10Count = 0;
+    let foundRank = null;
+    let foundUrl = null;
+    let top10Count = 0;
 
     while (currentPage <= 5) {
       const searchURL = `https://www.google.com/search?q=${encodeURIComponent(
@@ -69,27 +68,16 @@ export default async function handler(req, res) {
 
       searchResults = searchResults.concat(pageResults);
 
-      // const megagongResult = searchResults.find((result) =>
-      //   result.url.includes("megagong.net")
-      // );
-      // megagongTop10Count = searchResults.filter(
-      //   (r) => r.url.includes("megagong.net") && r.rank <= 10
-      // ).length;
-      const gongResult = searchResults.find((result) =>
-        result.url.includes("gong.conects.com")
+      const domainResult = searchResults.find((result) =>
+        result.url.includes(targetDomain)
       );
-      gongTop10Count = searchResults.filter(
-        (r) => r.url.includes("gong.conects.com") && r.rank <= 10
+      top10Count = searchResults.filter(
+        (r) => r.url.includes(targetDomain) && r.rank <= 10
       ).length;
 
-      // if (megagongResult) {
-      //   foundMegagongRank = megagongResult.rank;
-      //   foundMegagongUrl = megagongResult.url;
-      //   break;
-      // }
-      if (gongResult) {
-        foundGongRank = gongResult.rank;
-        foundGongUrl = gongResult.url;
+      if (domainResult) {
+        foundRank = domainResult.rank;
+        foundUrl = domainResult.url;
         break;
       }
 
@@ -97,18 +85,11 @@ export default async function handler(req, res) {
     }
 
     await browser.close();
-    // res.status(200).json({
-    //   keyword,
-    //   activeRank: foundMegagongRank ? foundMegagongRank : "N/A",
-    //   sourceUrl: foundMegagongUrl,
-    //   top10Count: megagongTop10Count,
-    //   results: searchResults
-    // });
     res.status(200).json({
       keyword,
-      activeRank: foundGongRank ? foundGongRank : "N/A",
-      sourceUrl: foundGongUrl,
-      top10Count: gongTop10Count,
+      activeRank: foundRank ? foundRank : "N/A",
+      sourceUrl: foundUrl,
+      top10Count,
       results: searchResults
     });
   } catch (error) {


### PR DESCRIPTION
## Summary
- split keyword manager into independent lists for 넥스트공무원 and 공단기
- simplify styling after removing dual-group layout

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: recommends adding Next.js ESLint plugin)*

------
https://chatgpt.com/codex/tasks/task_e_68b69bc276908321826f370678e3b4ad