### PR TITLE
feat: integrate React Quill editor

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "echarts": "^5.5.0",
-    "echarts-for-react": "^3.0.2"
+    "echarts-for-react": "^3.0.2",
+    "react-quill": "^2.0.0"
   },
   "devDependencies": {
     "@types/node": "22.13.10",

--- a/src/app/editor/page.js
+++ b/src/app/editor/page.js
@@ -1,0 +1,9 @@
+"use client";
+
+import { useState } from "react";
+import RichTextEditor from "@/components/RichTextEditor";
+
+export default function EditorPage() {
+  const [value, setValue] = useState("");
+  return <RichTextEditor value={value} onChange={setValue} />;
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -5,6 +5,7 @@ import { useAuth } from "@/context/AuthContext";
 import useKeywordPermission from "@/hooks/useKeywordPermission";
 import dynamic from "next/dynamic";
 import styles from "./page.module.scss";
+import RichTextEditor from "@/components/RichTextEditor";
 
 const ReactECharts = dynamic(() => import("echarts-for-react"), {
   ssr: false
@@ -47,15 +48,10 @@ function getThemeVars() {
   };
 }
 
-/** 비고 줄바꿈 처리 */
+/** 비고 HTML 출력 */
 function renderNote(note) {
   if (!note || !note.trim()) return "없음";
-  return note.split("\n").map((line, idx) => (
-    <span key={idx}>
-      {line}
-      <br />
-    </span>
-  ));
+  return <span dangerouslySetInnerHTML={{ __html: note }} />;
 }
 
 /** rank 표시 텍스트 */
@@ -729,11 +725,10 @@ export default function Home() {
               <label htmlFor="seo_note" className={styles.noteLabel}>
                 비고
               </label>
-              <textarea
+              <RichTextEditor
                 id="seo_note"
                 value={note}
-                onChange={(e) => setNote(e.target.value)}
-                rows={4}
+                onChange={setNote}
                 placeholder="비고를 입력하세요"
                 className={styles.textarea}
               />
@@ -1002,11 +997,10 @@ export default function Home() {
                           <strong>비고</strong>
                           {editingDate === d ? (
                             <div className={styles.noteEdit}>
-                              <textarea
+                              <RichTextEditor
                                 className={styles.noteTextarea}
-                                rows={4}
                                 value={editingNote}
-                                onChange={(e) => setEditingNote(e.target.value)}
+                                onChange={setEditingNote}
                                 placeholder="비고를 입력하세요"
                               />
                               <div className={styles.noteEditActions}>

--- a/src/components/RichTextEditor.jsx
+++ b/src/components/RichTextEditor.jsx
@@ -1,0 +1,17 @@
+"use client";
+
+import dynamic from "next/dynamic";
+import "react-quill/dist/quill.snow.css";
+
+const ReactQuill = dynamic(() => import("react-quill"), { ssr: false });
+
+export default function RichTextEditor({ value, onChange, ...props }) {
+  return (
+    <ReactQuill
+      theme="snow"
+      value={value}
+      onChange={onChange}
+      {...props}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- add React Quill dependency
- implement `RichTextEditor` component using dynamic import and prop forwarding
- replace note textareas with `RichTextEditor` and render notes as HTML
- add example page demonstrating editor usage

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(requires interactive ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68ba6784317c83218b4f9387ecaa6e91